### PR TITLE
add build parameters in build.gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
+### Gradle ###
+.gradle/
+build/
+classes/
+
+### IntelliJ ###
+*.iml
+*.ipr
+*.iws
+.idea/
+out/
+
+
+### Other ###
 bin

--- a/build.gradle
+++ b/build.gradle
@@ -17,3 +17,8 @@ jar {
         from 'libs'
     }
 }
+
+allprojects {
+    sourceCompatibility = 1.6
+    targetCompatibility = 1.6
+}


### PR DESCRIPTION
* In project folder, run:  <kbd>./gradlew clean compileJava</kbd> to compile
* <kbd>javap -verbose</kbd> on the any .class file in classes folder. e.g. <kbd>javap -verbose Converter.class</kbd> 
* Then build: <kbd>./gradlew build -x test</kbd> (I skip the test)

On step 2, the result of javap was:
> minor version: 0
major version: 50

means it is Java 1.6 Bytecode